### PR TITLE
話しかけたときのプレイヤーの操作を追加

### DIFF
--- a/Assets/Scenes/TItle/SampleMainScene.unity
+++ b/Assets/Scenes/TItle/SampleMainScene.unity
@@ -293,6 +293,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7380884549817367794, guid: 7c1a1d9b4a7695d4d9985293f7f76286,
         type: 3}
+      propertyPath: player
+      value: 
+      objectReference: {fileID: 1730417288}
+    - target: {fileID: 7380884549817367794, guid: 7c1a1d9b4a7695d4d9985293f7f76286,
+        type: 3}
       propertyPath: searchNearNPC
       value: 
       objectReference: {fileID: 1460419319}
@@ -779,6 +784,12 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1730417288 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6626503895012448112, guid: 1b80aed50585236448d951105186f9a2,
+    type: 3}
+  m_PrefabInstance: {fileID: 700313826}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1851906401
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
・会話中はプレイヤーは動けないようにしました。
・現状だと選択されるNPCはプレイヤーから最短距離にいるNPCなので、NPCの方向に向いていなくても会話することが可能です。なので、プレイヤーが対象のNPCの方向に向くようにしました。